### PR TITLE
Do not display required symbol in State field when it is not required

### DIFF
--- a/includes/templates/bootstrap/templates/tpl_modules_common_address_format.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_common_address_format.php
@@ -2,7 +2,7 @@
 /**
  * Module Template
  * 
- * BOOTSTRAP v3.7.5
+ * BOOTSTRAP v3.7.10
  *
  * Displays address-book details/selection
  *

--- a/includes/templates/bootstrap/templates/tpl_modules_common_address_format.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_common_address_format.php
@@ -106,7 +106,7 @@ if (ACCOUNT_SUBURB === 'true') {
 if (ACCOUNT_STATE === 'true') {
     if ($flag_show_pulldown_states === true) {
 ?>
-<label class="inputLabel" for="stateZone" id="zoneLabel"><?= ENTRY_STATE ?></label><?php if (!empty(ENTRY_STATE_TEXT)) echo '<span class="alert">' . ENTRY_STATE_TEXT . '</span>' ?>
+<label class="inputLabel" for="stateZone" id="zoneLabel"><?= ENTRY_STATE ?></label><span class="alert"><?= ((!empty(ENTRY_STATE_TEXT) && (int)ENTRY_STATE_MIN_LENGTH > 0) ? ENTRY_STATE_TEXT : '') ?></span>
 
 <?php
       echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"');
@@ -118,7 +118,7 @@ if (ACCOUNT_STATE === 'true') {
 
 <label class="inputLabel" for="state" id="stateLabel"><?= $state_field_label ?></label>
 <?php
-    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" class="form-control" placeholder="' . ENTRY_STATE_TEXT . '"');
+    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" class="form-control"' . ((int)ENTRY_STATE_MIN_LENGTH > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
     if ($flag_show_pulldown_states === false) {
         echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
     }

--- a/includes/templates/bootstrap/templates/tpl_modules_create_account.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_create_account.php
@@ -105,7 +105,7 @@ if (ACCOUNT_SUBURB === 'true') {
 if (ACCOUNT_STATE === 'true') {
     if ($flag_show_pulldown_states === true) {
 ?>
-            <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label><?php if (zen_not_null(ENTRY_STATE_TEXT)) echo '<span class="alert">' . ENTRY_STATE_TEXT . '</span>';?>
+            <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label><span class="alert"><?= ((zen_not_null(ENTRY_STATE_TEXT) && (int)ENTRY_STATE_MIN_LENGTH > 0) ? ENTRY_STATE_TEXT : '') ?></span>
             <?php echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"'); ?>
             <div class="clearfix"></div>
 <?php
@@ -113,7 +113,7 @@ if (ACCOUNT_STATE === 'true') {
 ?>
             <label class="inputLabel" for="state" id="stateLabel"><?php echo $state_field_label; ?></label>
 <?php
-    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" class="form-control" placeholder="' . ENTRY_STATE_TEXT . '"');
+    echo zen_draw_input_field('state', '', zen_set_field_length(TABLE_ADDRESS_BOOK, 'entry_state', '40') . ' id="state" class="form-control"' . ((int)ENTRY_STATE_MIN_LENGTH > 0 ? ' placeholder="' . ENTRY_STATE_TEXT . '"' : ''));
     if ($flag_show_pulldown_states === false) {
         echo zen_draw_hidden_field('zone_id', $zone_name, ' ');
     }

--- a/includes/templates/bootstrap/templates/tpl_modules_create_account.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_create_account.php
@@ -2,7 +2,7 @@
 /**
  * Page Template
  *
- * BOOTSTRAP v3.7.0
+ * BOOTSTRAP v3.7.10
  *
  * Loaded automatically by index.php?main_page=create_account.<br />
  * Displays Create Account form.

--- a/includes/templates/bootstrap/templates/tpl_modules_create_account.php
+++ b/includes/templates/bootstrap/templates/tpl_modules_create_account.php
@@ -105,7 +105,7 @@ if (ACCOUNT_SUBURB === 'true') {
 if (ACCOUNT_STATE === 'true') {
     if ($flag_show_pulldown_states === true) {
 ?>
-            <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label><span class="alert"><?= ((zen_not_null(ENTRY_STATE_TEXT) && (int)ENTRY_STATE_MIN_LENGTH > 0) ? ENTRY_STATE_TEXT : '') ?></span>
+            <label class="inputLabel" for="stateZone" id="zoneLabel"><?php echo ENTRY_STATE; ?></label><span class="alert"><?= ((!empty(ENTRY_STATE_TEXT) && (int)ENTRY_STATE_MIN_LENGTH > 0) ? ENTRY_STATE_TEXT : '') ?></span>
             <?php echo zen_draw_pull_down_menu('zone_id', zen_prepare_country_zones_pull_down($selected_country), $zone_id, 'id="stateZone"'); ?>
             <div class="clearfix"></div>
 <?php


### PR DESCRIPTION
Prevents required symbol to be displayed in state field (both drop down and input text) when the field is not required due to admin setting `ENTRY_STATE_MIN_LENGTH = 0`.
Modification similar to ZC PR #7701.

Ref #528