### PR TITLE
Fix malformed Specials link in mobile menu

### DIFF
--- a/includes/templates/bootstrap/common/tpl_offcanvas_menu.php
+++ b/includes/templates/bootstrap/common/tpl_offcanvas_menu.php
@@ -45,7 +45,7 @@ if ($tplSetting->SHOW_CATEGORIES_BOX_SPECIALS === 'true') {
     if (!$show_this->EOF) {
 ?>
         <div class="dropdown-divider"></div>
-        <a class="dropdown-item" href="<?= zen_href_link(FILENAME_SPECIALS) ?>'">
+        <a class="dropdown-item" href="<?= zen_href_link(FILENAME_SPECIALS) ?>">
             <?= CATEGORIES_BOX_HEADING_SPECIALS ?>
         </a>
 <?php

--- a/includes/templates/bootstrap/common/tpl_offcanvas_menu.php
+++ b/includes/templates/bootstrap/common/tpl_offcanvas_menu.php
@@ -2,7 +2,7 @@
 /**
  * Template for Mobile Header Drop Down
  * 
- * BOOTSTRAP v3.8.0
+ * BOOTSTRAP v3.8.1
  *
  * @copyright Copyright 2003-2020 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce


### PR DESCRIPTION
Removes a stray apostrophe from the Specials link generated by
`tpl_offcanvas_menu.php`.

The malformed link currently produces a URL ending in:

`index.php?main_page=specials'`